### PR TITLE
Updated ProfileName constants in 1.6 implementation

### DIFF
--- a/ocpp1.6/core/core.go
+++ b/ocpp1.6/core/core.go
@@ -31,7 +31,7 @@ type ChargePointHandler interface {
 }
 
 // THe profile name
-var ProfileName = "core"
+var ProfileName = "Core"
 
 // Provides support for Basic Charge Point functionality comparable with OCPP 1.5.
 var Profile = ocpp.NewProfile(

--- a/ocpp1.6/firmware/firmware.go
+++ b/ocpp1.6/firmware/firmware.go
@@ -18,7 +18,7 @@ type ChargePointHandler interface {
 }
 
 // The profile name
-const ProfileName = "firmwareManagement"
+const ProfileName = "FirmwareManagement"
 
 // Provides support for firmware update management and diagnostic log file download.
 var Profile = ocpp.NewProfile(

--- a/ocpp1.6/localauth/local_auth_list.go
+++ b/ocpp1.6/localauth/local_auth_list.go
@@ -14,7 +14,7 @@ type ChargePointHandler interface {
 }
 
 // The profile name
-const ProfileName = "localAuthList"
+const ProfileName = "LocalAuthListManagement"
 
 // Provides support for managing the local authorization list in Charge Points.
 var Profile = ocpp.NewProfile(

--- a/ocpp1.6/reservation/reservation.go
+++ b/ocpp1.6/reservation/reservation.go
@@ -14,7 +14,7 @@ type ChargePointHandler interface {
 }
 
 // The profile name
-const ProfileName = "reservation"
+const ProfileName = "Reservation"
 
 // Provides support for for reservation of a Charge Point.
 var Profile = ocpp.NewProfile(


### PR DESCRIPTION
Updated ProfileName constants in 1.6 implementation to match the SupportedProfiles allowed values in OCPP 1.6 specification