### PR TITLE
fix ocpp1.6 certificates use correct types

### DIFF
--- a/ocpp1.6/certificates/get_installed_certificates.go
+++ b/ocpp1.6/certificates/get_installed_certificates.go
@@ -3,7 +3,7 @@ package certificates
 import (
 	"reflect"
 
-	"github.com/lorenzodonini/ocpp-go/ocpp2.0.1/types"
+	"github.com/lorenzodonini/ocpp-go/ocpp1.6/types"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -31,14 +31,14 @@ func isValidGetInstalledCertificateStatus(fl validator.FieldLevel) bool {
 
 // The field definition of the GetInstalledCertificateIdsRequest PDU sent by the CSMS to the Charging Station.
 type GetInstalledCertificateIdsRequest struct {
-	CertificateTypes []types.CertificateUse `json:"certificateType" validate:"omitempty,dive,certificateUse16"`
+	CertificateType types.CertificateUse `json:"certificateType" validate:"omitempty,certificateUse16"`
 }
 
 // The field definition of the GetInstalledCertificateIds response payload sent by the Charging Station to the CSMS in response to a GetInstalledCertificateIdsRequest.
 type GetInstalledCertificateIdsResponse struct {
-	Status                   GetInstalledCertificateStatus    `json:"status" validate:"required,getInstalledCertificateStatus16"`
-	StatusInfo               *types.StatusInfo                `json:"statusInfo,omitempty" validate:"omitempty"`
-	CertificateHashDataChain []types.CertificateHashDataChain `json:"certificateHashData,omitempty" validate:"omitempty,dive"`
+	Status              GetInstalledCertificateStatus `json:"status" validate:"required,getInstalledCertificateStatus16"`
+	StatusInfo          *types.StatusInfo             `json:"statusInfo,omitempty" validate:"omitempty"`
+	CertificateHashData []types.CertificateHashData   `json:"certificateHashData,omitempty" validate:"omitempty,dive"`
 }
 
 // To facilitate the management of the Charging Station’s installed certificates, a method of retrieving the installed certificates is provided.

--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -367,14 +367,14 @@ func isValidGenericStatus(fl validator.FieldLevel) bool {
 type CertificateUse string
 
 const (
-	CSMSRootCertificate         CertificateUse = "CSMSRootCertificate"
-	ManufacturerRootCertificate CertificateUse = "ManufacturerRootCertificate"
+	CentralSystemRootCertificate CertificateUse = "CentralSystemRootCertificate"
+	ManufacturerRootCertificate  CertificateUse = "ManufacturerRootCertificate"
 )
 
 func isValidCertificateUse(fl validator.FieldLevel) bool {
 	use := CertificateUse(fl.Field().String())
 	switch use {
-	case CSMSRootCertificate, ManufacturerRootCertificate:
+	case CentralSystemRootCertificate, ManufacturerRootCertificate:
 		return true
 	default:
 		return false

--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -425,7 +425,7 @@ func init() {
 	_ = Validate.RegisterValidation("location16", isValidLocation)
 	_ = Validate.RegisterValidation("unitOfMeasure", isValidUnitOfMeasure)
 	_ = Validate.RegisterValidation("certificateSigningUse16", isValidCertificateSigningUse)
-	_ = Validate.RegisterValidation("isValidCertificateUse", isValidCertificateSigningUse)
+	_ = Validate.RegisterValidation("certificateUse16", isValidCertificateSigningUse)
 	_ = Validate.RegisterValidation("genericStatus16", isValidGenericStatus)
 	_ = Validate.RegisterValidation("hashAlgorithm16", isValidHashAlgorithmType)
 }

--- a/ocpp1.6/v16.go
+++ b/ocpp1.6/v16.go
@@ -350,6 +350,7 @@ func NewCentralSystem(endpoint *ocppj.Server, server ws.WsServer) CentralSystem 
 			logging.Profile,
 			security.Profile,
 			securefirmware.Profile,
+			certificates.Profile,
 		)
 	}
 	cs := newCentralSystem(endpoint)


### PR DESCRIPTION
ocpp1.6 implementation for certificate handling uses types from 2.0.1
Attached screenshots for convenience

<img width="1048" alt="image" src="https://github.com/GLCharge/ocpp-go/assets/5340333/95b32edf-e5d3-4c2f-b65d-05b182ca3f1b">
<img width="1076" alt="image" src="https://github.com/GLCharge/ocpp-go/assets/5340333/e1a2576a-e57e-43ad-9556-d9dba46705f6">
<img width="1064" alt="image" src="https://github.com/GLCharge/ocpp-go/assets/5340333/d09e8283-5289-48c8-9625-dd47fb809a36">
